### PR TITLE
Add rule-based refinement for tilt predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,15 @@
     차트를 구성할 수 있습니다.
 
 각 엔드포인트는 JSON 응답을 제공하며, 실패 시 `ok: false`와 함께 위의 에러 코드를 전달합니다. 프런트엔드는 이를 바탕으로 사용자에게 명확한 피드백을 표시할 수 있습니다.
+
+## 개발 팁: 파이썬 모듈 빠르게 문법 점검하기
+
+새로 작성한 서버 스크립트가 파이썬 문법을 충족하는지 빠르게 확인하고 싶다면 [`compileall`](https://docs.python.org/3/library/compileall.html) 모듈을 활용할 수 있습니다.
+
+```bash
+python -m compileall code/server/predictor.py \
+                       code/server/tilt_refinement.py \
+                       code/server/evaluate_rule_based_accuracy.py
+```
+
+위 명령은 지정한 세 파일을 바이트코드로 컴파일해 `.pyc` 파일을 생성합니다. 컴파일 과정에서 문법 오류가 발견되면 어느 파일의 몇 번째 줄에서 문제가 발생했는지 즉시 알려주기 때문에, 테스트를 돌리기 전에 빠르게 문법 오류를 잡는 용도로 유용합니다. 별도의 출력이 없다면 세 파일 모두 성공적으로 컴파일된 것이며, 이미 생성된 `.pyc` 파일은 자동으로 `__pycache__/` 폴더에 저장됩니다.

--- a/code/server/estmate_rnn.py
+++ b/code/server/estmate_rnn.py
@@ -1,0 +1,214 @@
+"""Compute F1 scores and confusion matrices for the RNN with and without heuristics."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import torch
+from sklearn.metrics import classification_report, confusion_matrix, f1_score
+from torch.utils.data import DataLoader
+
+if __package__ in (None, ""):
+    SERVER_DIR = Path(__file__).resolve().parent
+    CODE_DIR = SERVER_DIR.parent
+    ROOT_DIR = CODE_DIR.parent
+    for path in (str(ROOT_DIR), str(CODE_DIR)):
+        if path not in sys.path:
+            sys.path.append(path)
+    from data.posture_data import PostureDataset
+    from model.rnn_posture_model import RNNPostureModel
+    from tilt_refinement import refine_tilt_prediction
+else:  # pragma: no cover
+    from ..data.posture_data import PostureDataset
+    from ..model.rnn_posture_model import RNNPostureModel
+    from .tilt_refinement import refine_tilt_prediction
+
+
+def parse_args() -> argparse.Namespace:
+    code_dir = Path(__file__).resolve().parents[1]
+    default_model = code_dir / "model" / "rnn_posture_model2.pth"
+    default_dataset = code_dir / "data" / "dataset" / "posture_chunk_data.csv"
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-path", type=Path, default=default_model, help="Path to the trained RNN weights (.pth)")
+    parser.add_argument("--dataset-path", type=Path, default=default_dataset, help="CSV dataset used for evaluation")
+    parser.add_argument("--batch-size", type=int, default=128, help="Batch size for dataloader")
+    parser.add_argument("--device", type=str, default="cpu", help="Computation device (e.g. 'cpu', 'cuda:0')")
+    parser.add_argument(
+        "--average",
+        type=str,
+        default="macro",
+        choices=["micro", "macro", "weighted", "none"],
+        help="Averaging strategy for the reported F1 score (set to 'none' for per-class values)",
+    )
+    return parser.parse_args()
+
+
+def _collect_predictions(
+    dataloader: DataLoader,
+    model: RNNPostureModel,
+    device: torch.device,
+    label_encoder,
+) -> tuple[list[int], list[int], list[int]]:
+    all_targets: list[int] = []
+    all_rnn_preds: list[int] = []
+    all_refined_preds: list[int] = []
+
+    tilt_labels = {"shoulder_tilt", "head_tilt"}
+
+    with torch.no_grad():
+        for batch_inputs, batch_targets in dataloader:
+            batch_inputs = batch_inputs.to(device)
+            batch_targets = batch_targets.to(device)
+
+            logits = model(batch_inputs)
+            raw_predictions = logits.argmax(dim=1)
+            probabilities = torch.softmax(logits, dim=1)
+
+            if probabilities.size(1) >= 2:
+                top2 = torch.topk(probabilities, k=2, dim=1)
+                margins = top2.values[:, 0] - top2.values[:, 1]
+            else:
+                margins = torch.ones(probabilities.size(0), device=probabilities.device)
+
+            all_targets.extend(batch_targets.detach().cpu().tolist())
+            all_rnn_preds.extend(raw_predictions.detach().cpu().tolist())
+
+            raw_labels = label_encoder.inverse_transform(raw_predictions.detach().cpu().numpy())
+            inputs_cpu = batch_inputs.detach().cpu()
+            margins_cpu = margins.detach().cpu()
+
+            refined_indices: list[int] = []
+            for idx, raw_label in enumerate(raw_labels):
+                refined_label = raw_label
+                if raw_label in tilt_labels:
+                    diff_sequence: Sequence[Sequence[float]] = inputs_cpu[idx].tolist()
+                    margin = margins_cpu[idx].item()
+                    refined_label = refine_tilt_prediction(
+                        raw_label,
+                        diff_sequence,
+                        initial_margin=margin,
+                    )
+                refined_indices.append(label_encoder.transform([refined_label])[0])
+
+            all_refined_preds.extend(refined_indices)
+
+    return all_targets, all_rnn_preds, all_refined_preds
+
+
+def _print_f1_scores(
+    average: str,
+    labels: list[int],
+    target_names: list[str],
+    y_true: np.ndarray,
+    y_pred_rnn: np.ndarray,
+    y_pred_refined: np.ndarray,
+) -> None:
+    print("=== F1 Scores ===")
+    average_param: str | None = None if average == "none" else average
+    if average_param is None:
+        rnn_scores = f1_score(y_true, y_pred_rnn, labels=labels, average=None, zero_division=0)
+        refined_scores = f1_score(y_true, y_pred_refined, labels=labels, average=None, zero_division=0)
+
+        print("RNN-only per-class F1:")
+        for name, score in zip(target_names, rnn_scores):
+            print(f"  {name:>20}: {score:.4f}")
+
+        print("Rule-refined per-class F1:")
+        for name, score in zip(target_names, refined_scores):
+            print(f"  {name:>20}: {score:.4f}")
+    else:
+        rnn_score = f1_score(y_true, y_pred_rnn, labels=labels, average=average_param, zero_division=0)
+        refined_score = f1_score(y_true, y_pred_refined, labels=labels, average=average_param, zero_division=0)
+
+        print(f"RNN-only F1 ({average_param}):      {rnn_score:.4f}")
+        print(f"Rule-refined F1 ({average_param}):  {refined_score:.4f}")
+        print(f"Delta:                         {refined_score - rnn_score:+.4f}")
+
+    print()
+
+
+def _print_classification_reports(
+    labels: list[int],
+    target_names: list[str],
+    y_true: np.ndarray,
+    y_pred_rnn: np.ndarray,
+    y_pred_refined: np.ndarray,
+) -> None:
+    print("=== Classification Reports ===")
+    print("RNN-only:")
+    print(classification_report(y_true, y_pred_rnn, labels=labels, target_names=target_names, zero_division=0))
+    print("Rule-refined:")
+    print(classification_report(y_true, y_pred_refined, labels=labels, target_names=target_names, zero_division=0))
+
+
+def _print_confusion_matrix(name: str, matrix: np.ndarray, target_names: list[str]) -> None:
+    print(f"{name} Confusion Matrix:")
+    width = max(len(label) for label in target_names)
+    header = " " * (width + 2) + " ".join(f"{label:>8}" for label in target_names)
+    print(header)
+    for idx, row in enumerate(matrix):
+        counts = " ".join(f"{value:>8}" for value in row)
+        print(f"{target_names[idx]:>{width}} | {counts}")
+    print()
+
+
+def evaluate(
+    model_path: Path,
+    dataset_path: Path,
+    batch_size: int,
+    device: torch.device,
+    average: str,
+) -> None:
+    dataset = PostureDataset(str(dataset_path))
+    dataloader = DataLoader(dataset, batch_size=batch_size)
+
+    model = RNNPostureModel().to(device)
+    state = torch.load(str(model_path), map_location=device)
+    model.load_state_dict(state)
+    model.eval()
+
+    label_encoder = dataset.get_label_encoder()
+
+    targets, rnn_preds, refined_preds = _collect_predictions(dataloader, model, device, label_encoder)
+
+    if not targets:
+        print("Dataset is empty; nothing to evaluate.")
+        return
+
+    labels = list(range(len(label_encoder.classes_)))
+    target_names = list(label_encoder.classes_)
+
+    y_true = np.array(targets)
+    y_pred_rnn = np.array(rnn_preds)
+    y_pred_refined = np.array(refined_preds)
+
+    print("=== Evaluation Summary ===")
+    print(f"Dataset: {dataset_path}")
+    print(f"Model:   {model_path}")
+    print(f"Samples evaluated: {len(targets)}")
+    print()
+
+    _print_f1_scores(average, labels, target_names, y_true, y_pred_rnn, y_pred_refined)
+    _print_classification_reports(labels, target_names, y_true, y_pred_rnn, y_pred_refined)
+
+    cm_rnn = confusion_matrix(y_true, y_pred_rnn, labels=labels)
+    cm_refined = confusion_matrix(y_true, y_pred_refined, labels=labels)
+
+    print("=== Confusion Matrices ===")
+    _print_confusion_matrix("RNN-only", cm_rnn, target_names)
+    _print_confusion_matrix("Rule-refined", cm_refined, target_names)
+
+
+def main() -> None:
+    args = parse_args()
+    device = torch.device(args.device)
+    average = args.average
+    evaluate(args.model_path, args.dataset_path, args.batch_size, device, average)
+
+
+if __name__ == "__main__":
+    main()

--- a/code/server/evaluate_rule_based_accuracy.py
+++ b/code/server/evaluate_rule_based_accuracy.py
@@ -1,0 +1,128 @@
+"""Compare RNN-only accuracy against the rule-refined pipeline."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Sequence
+
+import torch
+from torch.utils.data import DataLoader
+
+if __package__ in (None, ""):
+    SERVER_DIR = Path(__file__).resolve().parent
+    CODE_DIR = SERVER_DIR.parent
+    ROOT_DIR = CODE_DIR.parent
+    for path in (str(ROOT_DIR), str(CODE_DIR)):
+        if path not in sys.path:
+            sys.path.append(path)
+    from data.posture_data import PostureDataset
+    from model.rnn_posture_model import RNNPostureModel
+    from tilt_refinement import refine_tilt_prediction
+else:  # pragma: no cover - module import path when packaged
+    from ..data.posture_data import PostureDataset
+    from ..model.rnn_posture_model import RNNPostureModel
+    from .tilt_refinement import refine_tilt_prediction
+
+
+def parse_args() -> argparse.Namespace:
+    code_dir = Path(__file__).resolve().parents[1]
+    default_model = code_dir / "model" / "rnn_posture_model2.pth"
+    default_dataset = code_dir / "data" / "dataset" / "posture_chunk_data.csv"
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-path", type=Path, default=default_model, help="Path to the trained RNN weights (.pth)")
+    parser.add_argument("--dataset-path", type=Path, default=default_dataset, help="CSV dataset used for evaluation")
+    parser.add_argument("--batch-size", type=int, default=128, help="Batch size for dataloader")
+    parser.add_argument("--device", type=str, default="cpu", help="Computation device (e.g. 'cpu', 'cuda:0')")
+    return parser.parse_args()
+
+
+def evaluate(model_path: Path, dataset_path: Path, batch_size: int, device: torch.device) -> None:
+    dataset = PostureDataset(str(dataset_path))
+    dataloader = DataLoader(dataset, batch_size=batch_size)
+
+    model = RNNPostureModel().to(device)
+    state = torch.load(str(model_path), map_location=device)
+    model.load_state_dict(state)
+    model.eval()
+
+    label_encoder = dataset.get_label_encoder()
+
+    total_samples = 0
+    correct_rnn = 0
+    correct_refined = 0
+
+    tilt_cases = 0
+    tilt_changed = 0
+    tilt_fixed = 0
+    tilt_regressed = 0
+
+    tilt_labels = {"shoulder_tilt", "head_tilt"}
+
+    with torch.no_grad():
+        for batch_inputs, batch_targets in dataloader:
+            batch_inputs = batch_inputs.to(device)
+            batch_targets = batch_targets.to(device)
+
+            logits = model(batch_inputs)
+            raw_predictions = logits.argmax(dim=1)
+
+            correct_rnn += (raw_predictions == batch_targets).sum().item()
+
+            raw_labels = label_encoder.inverse_transform(raw_predictions.detach().cpu().numpy())
+            true_labels = label_encoder.inverse_transform(batch_targets.detach().cpu().numpy())
+
+            refined_indices = []
+            inputs_cpu = batch_inputs.detach().cpu()
+
+            for idx, raw_label in enumerate(raw_labels):
+                refined_label = raw_label
+                if raw_label in tilt_labels:
+                    diff_sequence: Sequence[Sequence[float]] = inputs_cpu[idx].tolist()
+                    refined_label = refine_tilt_prediction(raw_label, diff_sequence)
+
+                    tilt_cases += 1
+                    if refined_label != raw_label:
+                        tilt_changed += 1
+                    if raw_label != true_labels[idx] and refined_label == true_labels[idx]:
+                        tilt_fixed += 1
+                    if raw_label == true_labels[idx] and refined_label != true_labels[idx]:
+                        tilt_regressed += 1
+
+                refined_indices.append(label_encoder.transform([refined_label])[0])
+
+            refined_tensor = torch.tensor(refined_indices, device=device)
+            correct_refined += (refined_tensor == batch_targets).sum().item()
+
+            total_samples += batch_targets.numel()
+
+    acc_rnn = correct_rnn / total_samples if total_samples else 0.0
+    acc_refined = correct_refined / total_samples if total_samples else 0.0
+
+    print("=== Evaluation Summary ===")
+    print(f"Dataset: {dataset_path}")
+    print(f"Model:   {model_path}")
+    print(f"Samples evaluated: {total_samples}")
+    print()
+    print(f"RNN-only accuracy:    {acc_rnn:.4%}")
+    print(f"Rule-refined accuracy: {acc_refined:.4%}")
+    print(f"Delta:                {acc_refined - acc_rnn:+.4%}")
+
+    print()
+    print("--- Tilt refinement diagnostics ---")
+    print(f"Tilts encountered:              {tilt_cases}")
+    if tilt_cases:
+        print(f"Changed by refinement:          {tilt_changed}")
+        print(f"Errors corrected by refinement: {tilt_fixed}")
+        print(f"Correct-to-wrong regressions:   {tilt_regressed}")
+
+
+def main() -> None:
+    args = parse_args()
+    device = torch.device(args.device)
+    evaluate(args.model_path, args.dataset_path, args.batch_size, device)
+
+
+if __name__ == "__main__":
+    main()

--- a/code/server/predictor.py
+++ b/code/server/predictor.py
@@ -54,6 +54,18 @@ model.eval()
 dummy_dataset = PostureDataset(DATASET_PATH)
 label_encoder = dummy_dataset.get_label_encoder()
 
+KEYPOINT_ORDER = [
+    "left_shoulder",
+    "right_shoulder",
+    "left_ear",
+    "right_ear",
+    "left_eye",
+    "right_eye",
+    "nose",
+]
+
+KEYPOINT_TO_INDEX = {name: idx for idx, name in enumerate(KEYPOINT_ORDER)}
+
 def flatten_kp7(kp7):
     """ kp7: [[x,y,z], ... ×7] -> len=21 리스트로 평탄화 """
     flat = []
@@ -65,6 +77,56 @@ def flatten_kp7(kp7):
             return None
         flat.extend([float(x), float(y), float(z)])
     return flat  # len=21
+
+
+def _average_vertical_gap(diff_sequence, left_key, right_key):
+    """diff_sequence(list[list[float]]): frame별 baseline 차분(21길이)"""
+
+    left_idx = KEYPOINT_TO_INDEX[left_key] * 3 + 1  # dy 위치
+    right_idx = KEYPOINT_TO_INDEX[right_key] * 3 + 1
+
+    values = []
+    for frame_diff in diff_sequence:
+        try:
+            left_dy = frame_diff[left_idx]
+            right_dy = frame_diff[right_idx]
+        except (TypeError, IndexError):
+            return None
+        values.append(abs(left_dy - right_dy))
+
+    if not values:
+        return 0.0
+    return sum(values) / len(values)
+
+
+def refine_tilt_prediction(initial_label, diff_sequence):
+    """RNN이 shoulder/head tilt로 예측 시 추가 규칙으로 재분류"""
+
+    if not diff_sequence:
+        return initial_label
+
+    shoulder_gap = _average_vertical_gap(diff_sequence, "left_shoulder", "right_shoulder")
+    ear_gap = _average_vertical_gap(diff_sequence, "left_ear", "right_ear")
+
+    if shoulder_gap is None or ear_gap is None:
+        return initial_label
+
+    MIN_EAR_GAP = 0.02
+    MIN_SHOULDER_GAP = 0.02
+    HEAD_RATIO_THRESHOLD = 0.8
+    SHOULDER_DOMINANCE = 1.2
+
+    if shoulder_gap < MIN_SHOULDER_GAP and ear_gap < MIN_EAR_GAP:
+        return initial_label
+
+    if ear_gap >= MIN_EAR_GAP and ear_gap >= shoulder_gap * HEAD_RATIO_THRESHOLD:
+        return "head_tilt"
+
+    if shoulder_gap >= MIN_SHOULDER_GAP and shoulder_gap >= ear_gap * SHOULDER_DOMINANCE:
+        return "shoulder_tilt"
+
+    # 모호한 경우에는 기존 RNN 예측 유지
+    return initial_label
 
 @app.route("/health", methods=["GET"])
 def health():
@@ -170,6 +232,10 @@ def predict():
         out = model(x)
         pred_idx = out.argmax(dim=1).item()
         label = label_encoder.inverse_transform([pred_idx])[0]
+
+    if label in {"shoulder_tilt", "head_tilt"}:
+        refined_label = refine_tilt_prediction(label, diffs)
+        label = refined_label
 
     stored, error = record_posture_event(email, label, score=score, recorded_at=recorded_at)
     if not stored:

--- a/code/server/predictor.py
+++ b/code/server/predictor.py
@@ -172,8 +172,15 @@ def predict():
         pred_idx = out.argmax(dim=1).item()
         label = label_encoder.inverse_transform([pred_idx])[0]
 
+        probs = torch.softmax(out[0], dim=0)
+        if probs.numel() >= 2:
+            top2 = torch.topk(probs, k=2)
+            margin = (top2.values[0] - top2.values[1]).item()
+        else:
+            margin = 1.0
+
     if label in {"shoulder_tilt", "head_tilt"}:
-        refined_label = refine_tilt_prediction(label, diffs)
+        refined_label = refine_tilt_prediction(label, diffs, initial_margin=margin)
         label = refined_label
 
     stored, error = record_posture_event(email, label, score=score, recorded_at=recorded_at)

--- a/code/server/tilt_refinement.py
+++ b/code/server/tilt_refinement.py
@@ -1,0 +1,91 @@
+"""Utilities for refining shoulder/head tilt predictions with rule-based heuristics."""
+from __future__ import annotations
+
+from typing import Sequence
+
+KEYPOINT_ORDER = [
+    "left_shoulder",
+    "right_shoulder",
+    "left_ear",
+    "right_ear",
+    "left_eye",
+    "right_eye",
+    "nose",
+]
+
+KEYPOINT_TO_INDEX = {name: idx for idx, name in enumerate(KEYPOINT_ORDER)}
+
+
+def _average_vertical_gap(
+    diff_sequence: Sequence[Sequence[float]],
+    left_key: str,
+    right_key: str,
+) -> float | None:
+    """Return the mean vertical distance between two keypoints across frames.
+
+    Args:
+        diff_sequence: Iterable of per-frame baseline diffs with length 21 (flattened
+            XYZ values for the 7 keypoints).
+        left_key: Name of the left-side keypoint (must exist in ``KEYPOINT_TO_INDEX``).
+        right_key: Name of the right-side keypoint (must exist in ``KEYPOINT_TO_INDEX``).
+
+    Returns:
+        Average absolute difference between the Y coordinates of the two keypoints.
+        Returns ``None`` if the provided data is malformed.
+    """
+
+    left_idx = KEYPOINT_TO_INDEX[left_key] * 3 + 1  # dy 위치
+    right_idx = KEYPOINT_TO_INDEX[right_key] * 3 + 1
+
+    values = []
+    for frame_diff in diff_sequence:
+        try:
+            left_dy = frame_diff[left_idx]
+            right_dy = frame_diff[right_idx]
+        except (TypeError, IndexError):
+            return None
+        values.append(abs(left_dy - right_dy))
+
+    if not values:
+        return 0.0
+    return sum(values) / len(values)
+
+
+def refine_tilt_prediction(
+    initial_label: str,
+    diff_sequence: Sequence[Sequence[float]],
+) -> str:
+    """Refine raw RNN tilt predictions using keypoint-derived heuristics."""
+
+    if not diff_sequence:
+        return initial_label
+
+    shoulder_gap = _average_vertical_gap(diff_sequence, "left_shoulder", "right_shoulder")
+    ear_gap = _average_vertical_gap(diff_sequence, "left_ear", "right_ear")
+
+    if shoulder_gap is None or ear_gap is None:
+        return initial_label
+
+    MIN_EAR_GAP = 0.02
+    MIN_SHOULDER_GAP = 0.02
+    HEAD_RATIO_THRESHOLD = 0.8
+    SHOULDER_DOMINANCE = 1.2
+
+    if shoulder_gap < MIN_SHOULDER_GAP and ear_gap < MIN_EAR_GAP:
+        return initial_label
+
+    if ear_gap >= MIN_EAR_GAP and ear_gap >= shoulder_gap * HEAD_RATIO_THRESHOLD:
+        return "head_tilt"
+
+    if shoulder_gap >= MIN_SHOULDER_GAP and shoulder_gap >= ear_gap * SHOULDER_DOMINANCE:
+        return "shoulder_tilt"
+
+    # 모호한 경우에는 기존 RNN 예측 유지
+    return initial_label
+
+
+__all__ = [
+    "KEYPOINT_ORDER",
+    "KEYPOINT_TO_INDEX",
+    "refine_tilt_prediction",
+]

--- a/code/server/tilt_refinement.py
+++ b/code/server/tilt_refinement.py
@@ -51,19 +51,65 @@ def _average_vertical_gap(
     return sum(values) / len(values)
 
 
+def _average_signed_delta(
+    diff_sequence: Sequence[Sequence[float]],
+    left_key: str,
+    right_key: str,
+) -> float | None:
+    """Return the mean signed height delta between two keypoints."""
+
+    left_idx = KEYPOINT_TO_INDEX[left_key] * 3 + 1
+    right_idx = KEYPOINT_TO_INDEX[right_key] * 3 + 1
+
+    values = []
+    for frame_diff in diff_sequence:
+        try:
+            left_dy = frame_diff[left_idx]
+            right_dy = frame_diff[right_idx]
+        except (TypeError, IndexError):
+            return None
+        values.append(left_dy - right_dy)
+
+    if not values:
+        return 0.0
+    return sum(values) / len(values)
+
+
 def refine_tilt_prediction(
     initial_label: str,
     diff_sequence: Sequence[Sequence[float]],
+    *,
+    initial_margin: float | None = None,
 ) -> str:
-    """Refine raw RNN tilt predictions using keypoint-derived heuristics."""
+    """Refine raw RNN tilt predictions using keypoint-derived heuristics.
+
+    Args:
+        initial_label: Label predicted by the neural network.
+        diff_sequence: Baseline-subtracted keypoint differences for each frame.
+        initial_margin: Difference between the top-1 and top-2 softmax
+            probabilities for the raw prediction. When the model is confident
+            (margin above ~0.12), the heuristic keeps the neural network output
+            untouched to avoid harming accuracy.
+    """
 
     if not diff_sequence:
         return initial_label
 
+    if initial_margin is not None and initial_margin >= 0.12:
+        # RNN has a confident margin between the top-2 classes; respect it.
+        return initial_label
+
     shoulder_gap = _average_vertical_gap(diff_sequence, "left_shoulder", "right_shoulder")
     ear_gap = _average_vertical_gap(diff_sequence, "left_ear", "right_ear")
+    shoulder_signed = _average_signed_delta(diff_sequence, "left_shoulder", "right_shoulder")
+    ear_signed = _average_signed_delta(diff_sequence, "left_ear", "right_ear")
 
-    if shoulder_gap is None or ear_gap is None:
+    if (
+        shoulder_gap is None
+        or ear_gap is None
+        or shoulder_signed is None
+        or ear_signed is None
+    ):
         return initial_label
 
     # 노이즈를 제거하기 위해 양쪽 모두 거의 움직임이 없으면 RNN 결과를 그대로 사용합니다.
@@ -74,19 +120,24 @@ def refine_tilt_prediction(
     ratio = ear_gap / (shoulder_gap + 1e-6)
     dominance = shoulder_gap - ear_gap
 
+    # 귀와 어깨가 상반된 방향으로 움직였다면 신뢰하지 않습니다.
+    if shoulder_signed * ear_signed < 0:
+        return initial_label
+
     # 귀 높이 차이가 충분히 크고 어깨보다 확실히 우세하면 head_tilt 로 간주합니다.
     if (
-        ear_gap >= 0.04
-        and ratio >= 1.15
-        and dominance <= -0.015
+        ear_gap >= 0.045
+        and ratio >= 1.25
+        and dominance <= -0.02
     ):
         return "head_tilt"
 
     # 어깨 높이 차이가 귀보다 확실히 우세하고 절대값도 충분히 크면 shoulder_tilt 로 간주합니다.
     if (
-        shoulder_gap >= 0.06
-        and ratio <= 0.7
-        and dominance >= 0.03
+        shoulder_gap >= 0.065
+        and ratio <= 0.6
+        and dominance >= 0.035
+        and abs(shoulder_signed) >= abs(ear_signed) * 0.9
     ):
         return "shoulder_tilt"
 


### PR DESCRIPTION
## Summary
- add keypoint metadata and helpers for evaluating vertical keypoint gaps
- apply a rule-based refinement when the RNN predicts shoulder/head tilt to stabilize the label sent to the client

## Testing
- python -m compileall code/server/predictor.py

------
https://chatgpt.com/codex/tasks/task_e_68f5a76332ac83308ed8d8990af12580